### PR TITLE
Add "active" users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,16 +15,22 @@ class User < ApplicationRecord
   validates :first_name, presence: true, if: -> { last_name.blank? }
   validates :calendar_access_token, uniqueness: { case_sensitive: true }
 
-  def self.find_for_oauth(auth)
-    find_by(provider: auth.provider, uid: auth.uid)
-  end
+  class << self
+    def active
+      invitation_accepted.joins(:events).where(events: { start_date: (5.years.ago..) }).distinct
+    end
 
-  def self.to_notify(override: false)
-    override ? all : where(email_updates: true)
+    def find_for_oauth(auth)
+      find_by(provider: auth.provider, uid: auth.uid)
+    end
+
+    def to_notify(override: false)
+      override ? all : where(email_updates: true)
+    end
   end
 
   def full_name
-    "#{first_name} #{last_name}"
+    [first_name, last_name].join(' ').strip
   end
 
   def invitation_limit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,14 @@ class User < ApplicationRecord
       invitation_accepted.joins(:events).where(events: { start_date: (5.years.ago..) }).distinct
     end
 
+    # :nocov:
+    def dev_login_options
+      order(:first_name, :last_name).group_by { |u| u.admin? ? 'Admins' : 'Non-Admins' }.transform_values do |users|
+        users.map { |u| [u.full_name, u.id] }
+      end
+    end
+    # :nocov:
+
     def find_for_oauth(auth)
       find_by(provider: auth.provider, uid: auth.uid)
     end
@@ -28,14 +36,6 @@ class User < ApplicationRecord
       override ? all : where(email_updates: true)
     end
   end
-
-  # :nocov:
-  def self.dev_login_options
-    order(:first_name, :last_name).group_by { |u| u.admin? ? 'Admins' : 'Non-Admins' }.transform_values do |users|
-      users.map { |u| [u.full_name, u.id] }
-    end
-  end
-  # :nocov:
 
   def full_name
     [first_name, last_name].join(' ').strip


### PR DESCRIPTION
Part of #229, adds the concept of "active user" of the site: they've accepted their invitation and made at least one event in the last 5 years.

Also fixed a bug in the "full name" if users only have first names