### PR TITLE
Update Bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -636,7 +636,7 @@ CHECKSUMS
   bootstrap_form (5.6.1) sha256=ec4ac273ce0eae0e6d13fc12e8ceb96ad4498e47f440a1fb1d06ac8a990b8689
   brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
+  bundler (4.0.16) sha256=d6ca5dd440c24f9abce9844cf44cc8e18c6a553de65a47efb4544137af92c47d
   capistrano (3.20.1) sha256=b0d54ba5cf49bb194998bf6b427e889aa36ed05f545ecf7cc37acb9d529e9ae9
   capistrano-bundler (2.2.0) sha256=47b4cf2ea17ea132bb0a5cabc5663443f5190a54f4da5b322d04e1558ff1468c
   capistrano-passenger (0.2.1) sha256=07a1d25edd5c1d909c19d4fe45fe2ea5f11200569f6967f6bff1d605ade98e13
@@ -809,4 +809,4 @@ RUBY VERSION
   ruby 4.0.1p0
 
 BUNDLED WITH
-  4.0.14
+  4.0.16


### PR DESCRIPTION
Still working on figuring out why _my_ bundler removes the checksum for bundler.

Turns out it's ruby/rubygems#9512

Its fixed on my machine for now, and ruby/rubygems#9658 should stop the churn once it's released.